### PR TITLE
fix: make only last ermShark count for drops/kills

### DIFF
--- a/Content/NPCs/ErmSharkDropRule.cs
+++ b/Content/NPCs/ErmSharkDropRule.cs
@@ -1,0 +1,36 @@
+using Neurosama.Content.NPCs;
+using Terraria.GameContent.ItemDropRules;
+using Terraria.Localization;
+
+
+public class ErmsharkLastDescendantDropRule : IItemDropRuleCondition
+{
+	private static LocalizedText Description;
+
+	public ErmsharkLastDescendantDropRule()
+	{
+		Description = Language.GetText("Mods.Neurosama.DropConditions.Ermshark");
+	}
+
+
+	/// <summary>
+	/// Checks if the NPC is the last <see cref="ErmShark"/> alive.
+	/// </summary>
+	/// <param name="info">The drop attempt information.</param>
+	/// <returns><c>true</c> if the NPC is the last <see cref="ErmShark"/> alive, <c>false</c> otherwise.</returns>
+	public bool CanDrop(DropAttemptInfo info)
+	{
+		// i have no idea if this is the best way, but it doesn't appear to lag even with a lot of erms
+		return info.npc.ModNPC is ErmShark ermShark && ermShark.IsLastDescendant();
+	}
+
+	public bool CanShowItemDropInUI()
+	{
+		return true;
+	}
+
+	public string GetConditionDescription()
+	{
+		return Description.Value;
+	}
+}

--- a/Localization/en-US_Mods.Neurosama.hjson
+++ b/Localization/en-US_Mods.Neurosama.hjson
@@ -287,5 +287,8 @@ Buffs: {
 	}
 }
 
+DropConditions: {
+	Ermshark: ""
+}
 Projectiles.SwarmDrone.DisplayName: Activated Swarm Drone
 UI.SayItBack: Say It Back


### PR DESCRIPTION
Our previous code was indiscriminate. As we were spawning new NPCs, they were completely independent entities.

While that has not changed, we have at least added a few sanity checks to ensure that only our last descendant (e.g., direct spawns from a given naturally spawned ermShark) counts for post-kill updates, such as kill tallying for the Bestiary and drop rules.

Our ErmSharkDropRule class exists only due to a TModLoader requirement to have an external class tied to a conditional NPC Loot ItemDropRule.

The description entry should be empty as this is a Global/Terrain conditional rather than an actual unlock conditional.